### PR TITLE
1 - Uncomment JUNIT tests

### DIFF
--- a/quora-api/src/main/java/com/upgrad/quora/api/exception/RestExceptionHandler.java
+++ b/quora-api/src/main/java/com/upgrad/quora/api/exception/RestExceptionHandler.java
@@ -44,7 +44,7 @@ public class RestExceptionHandler {
      */
     @ExceptionHandler(AuthorizationFailedException.class)
     public ResponseEntity<ErrorResponse> authorizationFailedException(AuthorizationFailedException exception, WebRequest request) {
-        return new ResponseEntity<ErrorResponse>(new ErrorResponse().code(exception.getCode()).message(exception.getErrorMessage()), HttpStatus.UNAUTHORIZED);
+        return new ResponseEntity<ErrorResponse>(new ErrorResponse().code(exception.getCode()).message(exception.getErrorMessage()), HttpStatus.FORBIDDEN);
     }
 
     /**
@@ -93,7 +93,7 @@ public class RestExceptionHandler {
      */
     @ExceptionHandler(InvalidQuestionException.class)
     public ResponseEntity<ErrorResponse> invalidQuestionException(InvalidQuestionException exception, WebRequest request) {
-        return new ResponseEntity<ErrorResponse>(new ErrorResponse().code(exception.getCode()).message(exception.getErrorMessage()), HttpStatus.UNAUTHORIZED);
+        return new ResponseEntity<ErrorResponse>(new ErrorResponse().code(exception.getCode()).message(exception.getErrorMessage()), HttpStatus.NOT_FOUND);
     }
 
     /** Triggered when the user passed answer ID doesnt exist

--- a/quora-api/src/test/java/com/upgrad/quora/api/controller/AdminControllerTest.java
+++ b/quora-api/src/test/java/com/upgrad/quora/api/controller/AdminControllerTest.java
@@ -1,4 +1,4 @@
-package com.upgrad.quora.api.controller;/*package com.upgrad.quora.api.controller;
+package com.upgrad.quora.api.controller;
 
 
 import org.junit.Test;
@@ -50,4 +50,3 @@ public class AdminControllerTest {
 
 
 }
-*/

--- a/quora-api/src/test/java/com/upgrad/quora/api/controller/AnswerControllerTest.java
+++ b/quora-api/src/test/java/com/upgrad/quora/api/controller/AnswerControllerTest.java
@@ -1,4 +1,4 @@
-package com.upgrad.quora.api.controller;/*package com.upgrad.quora.api.controller;
+package com.upgrad.quora.api.controller;
 
 
 import org.junit.Test;
@@ -138,4 +138,3 @@ public class AnswerControllerTest {
 
 
 }
-*/

--- a/quora-api/src/test/java/com/upgrad/quora/api/controller/CommonControllerTest.java
+++ b/quora-api/src/test/java/com/upgrad/quora/api/controller/CommonControllerTest.java
@@ -1,4 +1,4 @@
-package com.upgrad.quora.api.controller;/*package com.upgrad.quora.api.controller;
+package com.upgrad.quora.api.controller;
 
 
 import org.junit.Test;
@@ -44,4 +44,3 @@ public class CommonControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("code").value("USR-001"));
     }
 }
-*/

--- a/quora-api/src/test/java/com/upgrad/quora/api/controller/QuestionControllerTest.java
+++ b/quora-api/src/test/java/com/upgrad/quora/api/controller/QuestionControllerTest.java
@@ -1,4 +1,4 @@
-package com.upgrad.quora.api.controller;/*package com.upgrad.quora.api.controller;
+package com.upgrad.quora.api.controller;
 
 
 import org.junit.Test;
@@ -154,4 +154,4 @@ public class QuestionControllerTest {
 
 
 }
-*/
+

--- a/quora-api/src/test/java/com/upgrad/quora/api/controller/UserControllerTest.java
+++ b/quora-api/src/test/java/com/upgrad/quora/api/controller/UserControllerTest.java
@@ -1,4 +1,4 @@
-package com.upgrad.quora.api.controller;/*package com.upgrad.quora.api.controller;
+package com.upgrad.quora.api.controller;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,4 +46,3 @@ public class UserControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("code").value("SGR-001"));
     }
 }
-*/

--- a/quora-service/src/main/java/com/upgrad/quora/service/business/CommonService.java
+++ b/quora-service/src/main/java/com/upgrad/quora/service/business/CommonService.java
@@ -28,11 +28,6 @@ public class CommonService {
         UserAuthTokenEntity authTokenEntity = authenticationService.getAuthToken(accessToken, "User has not signed in",
                 "User is signed out.Sign in first to get user details");
 
-/*        if (userId.equals(authTokenEntity.getUser().getUuid()) == false) {
-            throw new AuthorizationFailedException("ATHR-003", "The passed UUID and the User of the authorization token does not match");
-
-        }*/
-
         return userEntity;
     }
 }

--- a/quora-service/src/main/java/com/upgrad/quora/service/business/CommonService.java
+++ b/quora-service/src/main/java/com/upgrad/quora/service/business/CommonService.java
@@ -28,10 +28,10 @@ public class CommonService {
         UserAuthTokenEntity authTokenEntity = authenticationService.getAuthToken(accessToken, "User has not signed in",
                 "User is signed out.Sign in first to get user details");
 
-        if (userId.equals(authTokenEntity.getUser().getUuid()) == false) {
+/*        if (userId.equals(authTokenEntity.getUser().getUuid()) == false) {
             throw new AuthorizationFailedException("ATHR-003", "The passed UUID and the User of the authorization token does not match");
 
-        }
+        }*/
 
         return userEntity;
     }


### PR DESCRIPTION
2 - Return proper HTTP Status codes for error cases
3 - Remove an additional check causing the JUNIT test to fail